### PR TITLE
More freedom for styling the under construction page

### DIFF
--- a/code/UnderConstruction.php
+++ b/code/UnderConstruction.php
@@ -22,12 +22,12 @@ class UnderConstruction_Decorator extends DataExtension {
 			mkdir(ASSETS_PATH);
 		}
 
-		$pageUnderConstructionErrorPage = DataObject::get_one('ErrorPage', "\"ErrorCode\" = '503'");
+		$pageUnderConstructionErrorPage = DataObject::get_one('UnderConstructionErrorPage', "\"ErrorCode\" = '503'");
 		$pageUnderConstructionErrorPageExists = ($pageUnderConstructionErrorPage && $pageUnderConstructionErrorPage->exists()) ? true : false;
-		$pageUnderConstructionErrorPagePath = ErrorPage::get_filepath_for_errorcode(503);
+		$pageUnderConstructionErrorPagePath = UnderConstructionErrorPage::get_filepath_for_errorcode(503);
 		if(!($pageUnderConstructionErrorPageExists && file_exists($pageUnderConstructionErrorPagePath))) {
 			if(!$pageUnderConstructionErrorPageExists) {
-				$pageUnderConstructionErrorPage = new ErrorPage();
+				$pageUnderConstructionErrorPage = new UnderConstructionErrorPage();
 				$pageUnderConstructionErrorPage->ErrorCode = 503;
 				$pageUnderConstructionErrorPage->Title = _t('UnderConstruction.TITLE', 'Under Construction');
 				$pageUnderConstructionErrorPage->Content = _t('UnderConstruction.CONTENT', '<p>Sorry, this site is currently under construction.</p>');
@@ -75,7 +75,7 @@ class UnderConstruction_Extension extends Extension {
     if ($siteUnderConstruction) {
       
       //Check to see if running /dev/build
-      $runningDevBuild = $this->owner && $this->owner->data() instanceof ErrorPage;
+      $runningDevBuild = $this->owner && ($this->owner->data() instanceof ErrorPage || $this->owner->data() instanceof UnderConstructionErrorPage);
       
       if (!Permission::check('ADMIN') 
           && strpos($_SERVER['REQUEST_URI'], '/admin') === false 

--- a/code/UnderConstruction.php
+++ b/code/UnderConstruction.php
@@ -1,4 +1,13 @@
 <?php
+
+/**
+ * Under construction base class - allowing configuration
+ */
+class UnderConstruction extends Object {
+
+}
+
+
 /**
  * Decorator to essentially create a static under construction {@link ErrorPage} in the assets folder 
  * with the aid of requireDefaultRecords().
@@ -76,8 +85,18 @@ class UnderConstruction_Extension extends Extension {
       
       //Check to see if running /dev/build
       $runningDevBuild = $this->owner && ($this->owner->data() instanceof ErrorPage || $this->owner->data() instanceof UnderConstructionErrorPage);
-      
-      if (!Permission::check('ADMIN') 
+
+      //Check whether the current member is in any allowed groups
+      //You can set allowed groups in your config file
+      $inAllowedGroup = false;
+      $member = Member::currentUser();
+      if ($member && is_array($groups = UnderConstruction::config()->allowed_groups)) {
+          if ($member->inGroups($groups)) {
+              $inAllowedGroup = true;
+          }
+      }
+      if (!Permission::check('ADMIN')
+          && !$inAllowedGroup
           && strpos($_SERVER['REQUEST_URI'], '/admin') === false 
           && strpos($_SERVER['REQUEST_URI'], '/Security') === false 
           && !Director::isDev() 
@@ -88,6 +107,7 @@ class UnderConstruction_Extension extends Extension {
     }
   }
 }
+
 
 /**
  * Decorator to add settings to config to make it easier to make the site live and 

--- a/code/UnderConstructionErrorPage.php
+++ b/code/UnderConstructionErrorPage.php
@@ -1,0 +1,17 @@
+<?php
+class UnderConstructionErrorPage extends ErrorPage {
+}
+
+class UnderConstructionErrorPage_Controller extends ErrorPage_Controller {
+
+	public function init(){
+		parent::init();
+
+		//Allowing to clear requirements via config
+		if (UnderConstructionErrorPage::config()->ClearRequirements) {
+			Requirements::clear();
+		}
+
+	}
+
+}

--- a/code/UnderConstructionErrorPage.php
+++ b/code/UnderConstructionErrorPage.php
@@ -8,7 +8,7 @@ class UnderConstructionErrorPage_Controller extends ErrorPage_Controller {
 		parent::init();
 
 		//Allowing to clear requirements via config
-		if (UnderConstructionErrorPage::config()->ClearRequirements) {
+		if (UnderConstructionErrorPage::config()->clear_requirements) {
 			Requirements::clear();
 		}
 


### PR DESCRIPTION
I ran into 2 issues when styling the under construction page:
- I couldn't find a way for setting up a separate template
- All requirements would be loaded

Thus these changes. Don't know if you want them part of your repo? They help me.

You can clear the requirements with this setting:

``` yml
UnderConstructionErrorPage:
  ClearRequirements: true
```
